### PR TITLE
apache::proxypass defaults to a http enabled backend and can be overwritten

### DIFF
--- a/manifests/proxypass.pp
+++ b/manifests/proxypass.pp
@@ -41,7 +41,7 @@ define apache::proxypass (
   $url='',
   $params=[],
   $filename='',
-  $sslbackend=undef
+  $sslbackend=false
 ) {
 
   $fname = regsubst($name, '\s', '_', 'G')
@@ -58,7 +58,7 @@ define apache::proxypass (
     }
   }
 
-  if defined($sslbackend) {
+  if ($sslbackend) {
     if defined(Apache::Module['ssl']) {} else {
       apache::module {'ssl':
       }


### PR DESCRIPTION
Let's presume the apache::proxypass backend talks http by default and can be overwritten to https by setting sslbackend to true
